### PR TITLE
Watch new events only

### DIFF
--- a/pkg/client/events.go
+++ b/pkg/client/events.go
@@ -52,7 +52,7 @@ func (c *Client) EventLoop(w watch.Interface, handler func(watch.Event) error) {
 
 }
 
-// Filter checks whether event matchs configuration or not
+// Filter checks whether event matches configuration or not
 func (c *Client) Filter(e watch.Event) bool {
 	apiEvent := (e.Object).(*api.Event)
 	reason := apiEvent.Reason

--- a/pkg/client/run.go
+++ b/pkg/client/run.go
@@ -53,7 +53,12 @@ func Run(conf *config.Config) {
 		log.Fatal(err)
 	}
 
-	w, err := client.Events(api.NamespaceAll).Watch(api.ListOptions{Watch: true})
+	eventList, err := client.Events(api.NamespaceAll).List(api.ListOptions{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	w, err := client.Events(api.NamespaceAll).Watch(api.ListOptions{Watch: true, ResourceVersion: eventList.ResourceVersion})
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Kubenetes uses ResourceVersion for identifying new resource, but
there no way to directly get current ResourceVersion.

By performing a call to list events endpoint first, we can obtain
the newest ResourceVersion and passing it to watch endpoint.