### PR TITLE
Feature/multiple goroutine for client listeners

### DIFF
--- a/pkg/client/events_test.go
+++ b/pkg/client/events_test.go
@@ -21,10 +21,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/skippbox/kubewatch/config"
-
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/watch"
+
+	"github.com/skippbox/kubewatch/config"
+	"github.com/skippbox/kubewatch/pkg/event"
 )
 
 var configStr = `
@@ -83,7 +84,7 @@ func TestFilter(t *testing.T) {
 		apiEvent.Reason = tt.reason
 		e.Object = apiEvent
 
-		if client.Filter(e) != tt.expected {
+		if client.Filter(event.New(e)) != tt.expected {
 			t.Fatalf("TestFilter(): %+v", client)
 		}
 	}

--- a/pkg/client/kubewatch_test.go
+++ b/pkg/client/kubewatch_test.go
@@ -49,3 +49,15 @@ func TestEvents(t *testing.T) {
 		t.Fatal("Events(): wrong type")
 	}
 }
+
+func TestServices(t *testing.T) {
+	c, _ := New(nil, nil)
+
+	e := c.Services(api.NamespaceAll)
+
+	_, ok := e.(k8sClient.ServiceInterface)
+
+	if !ok {
+		t.Fatal("Services(): wrong type")
+	}
+}

--- a/pkg/client/run.go
+++ b/pkg/client/run.go
@@ -19,6 +19,8 @@ package client
 import (
 	"flag"
 	"log"
+	"os"
+	"os/signal"
 
 	"k8s.io/kubernetes/pkg/api"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -65,10 +67,39 @@ func Run(conf *config.Config) {
 		log.Fatal(err)
 	}
 
-	w, err := client.Events(api.NamespaceAll).Watch(api.ListOptions{Watch: true, ResourceVersion: eventList.ResourceVersion})
+	watchEvents, err := client.Events(api.NamespaceAll).Watch(api.ListOptions{
+		Watch:           true,
+		ResourceVersion: eventList.ResourceVersion,
+	})
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	client.EventLoop(w, eventHandler.Handle)
+	serviceList, err := client.Services(api.NamespaceAll).List(api.ListOptions{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	watchServices, err := client.Services(api.NamespaceAll).Watch(api.ListOptions{
+		Watch:           true,
+		ResourceVersion: serviceList.ResourceVersion,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	client.waitGroup.Add(2)
+	go client.EventLoop(watchEvents, eventHandler.Handle)
+	go client.EventLoop(watchServices, eventHandler.Handle)
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt)
+	defer signal.Stop(signals)
+
+	log.Println("Press Ctrl+C to quit...")
+	<-signals
+	log.Println("Exiting...")
+
+	client.Stop()
+	log.Println("Exited normally.")
 }

--- a/pkg/client/run.go
+++ b/pkg/client/run.go
@@ -98,7 +98,6 @@ func Run(conf *config.Config) {
 
 	log.Println("Press Ctrl+C to quit...")
 	<-signals
-	log.Println("Exiting...")
 
 	client.Stop()
 	log.Println("Exited normally.")

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2016 Skippbox, Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package event
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// Event represent an event got from k8s api server
+// Events from different endpoints need to be casted to KubewatchEvent
+// before being able to be handled by handler
+type Event struct {
+	Namespace string
+	Kind      string
+	Component string
+	Host      string
+	Reason    string
+	Status    string
+}
+
+// New create new KubewatchEvent
+func New(e watch.Event) Event {
+	var namespace, kind, component, host, reason, status string
+
+	if apiEvent, ok := (e.Object).(*api.Event); ok {
+		namespace = apiEvent.ObjectMeta.Namespace
+		kind = apiEvent.InvolvedObject.Kind
+		component = apiEvent.Source.Component
+		host = apiEvent.Source.Host
+		reason = apiEvent.Reason
+		status = apiEvent.Type
+	}
+
+	if apiService, ok := (e.Object).(*api.Service); ok {
+		namespace = apiService.ObjectMeta.Namespace
+		kind = apiService.Kind
+		component = string(apiService.Spec.Type)
+		reason = string(e.Type)
+		status = "Normal"
+	}
+
+	kbEvent := Event{
+		Namespace: namespace,
+		Kind:      kind,
+		Component: component,
+		Host:      host,
+		Reason:    reason,
+		Status:    status,
+	}
+
+	return kbEvent
+}

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -14,24 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package handlers
+package event
 
 import (
+	"log"
 	"testing"
 
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/watch"
-
-	"github.com/skippbox/kubewatch/pkg/event"
 )
 
-func TestDefaultHandle(t *testing.T) {
+func TestNewEvent(t *testing.T) {
+	e := watch.Event{}
+	apiEvent := &api.Event{}
+	apiEvent.Reason = "Test"
+	e.Object = apiEvent
 
-	w := watch.Event{}
-	d := &Default{}
+	kbEvent := New(e)
 
-	err := d.Handle(event.New(w))
-
-	if err != nil {
-		t.Fatal(err)
+	if kbEvent.Reason != apiEvent.Reason {
+		log.Fatalf("TestNewEvent()")
 	}
 }

--- a/pkg/handlers/handler.go
+++ b/pkg/handlers/handler.go
@@ -20,9 +20,8 @@ import (
 	"encoding/json"
 	"log"
 
-	"k8s.io/kubernetes/pkg/watch"
-
 	"github.com/skippbox/kubewatch/config"
+	"github.com/skippbox/kubewatch/pkg/event"
 	"github.com/skippbox/kubewatch/pkg/handlers/slack"
 )
 
@@ -30,7 +29,7 @@ import (
 // The Handle method is used to process event
 type Handler interface {
 	Init(c *config.Config) error
-	Handle(w watch.Event) error
+	Handle(e event.Event) error
 }
 
 // Map maps each event handler function to a name for easily lookup
@@ -52,7 +51,7 @@ func (d *Default) Init(c *config.Config) error {
 
 // Handle handles event for default handler,
 // print event in json format, for testing or debugging
-func (d *Default) Handle(e watch.Event) error {
+func (d *Default) Handle(e event.Event) error {
 	b, err := json.Marshal(e)
 	if err != nil {
 		return err

--- a/pkg/handlers/slack/slack.go
+++ b/pkg/handlers/slack/slack.go
@@ -22,10 +22,9 @@ import (
 	"os"
 
 	"github.com/nlopes/slack"
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/watch"
 
 	"github.com/skippbox/kubewatch/config"
+	"github.com/skippbox/kubewatch/pkg/event"
 )
 
 var slackColors = map[string]string{
@@ -74,7 +73,7 @@ func (s *Slack) Init(c *config.Config) error {
 
 // Handle handles event for slack handler,
 // send notify event to slack channel
-func (s *Slack) Handle(e watch.Event) error {
+func (s *Slack) Handle(e event.Event) error {
 	err := checkMissingSlackVars(s)
 	if err != nil {
 		return err
@@ -103,17 +102,17 @@ func checkMissingSlackVars(s *Slack) error {
 	return nil
 }
 
-func prepareSlackAttachment(e watch.Event) slack.Attachment {
-	apiEvent := (e.Object).(*api.Event)
+func prepareSlackAttachment(e event.Event) slack.Attachment {
 
 	msg := fmt.Sprintf(
 		"In *Namespace* %s *Kind* %s from *Component* %s on *Host* %s had *Reason* %s",
-		apiEvent.ObjectMeta.Namespace,
-		apiEvent.InvolvedObject.Kind,
-		apiEvent.Source.Component,
-		apiEvent.Source.Host,
-		apiEvent.Reason,
+		e.Namespace,
+		e.Kind,
+		e.Component,
+		e.Host,
+		e.Reason,
 	)
+
 	attachment := slack.Attachment{
 		Fields: []slack.AttachmentField{
 			slack.AttachmentField{
@@ -123,7 +122,7 @@ func prepareSlackAttachment(e watch.Event) slack.Attachment {
 		},
 	}
 
-	if color, ok := slackColors[apiEvent.Type]; ok {
+	if color, ok := slackColors[e.Status]; ok {
 		attachment.Color = color
 	}
 

--- a/pkg/handlers/slack/slack_test.go
+++ b/pkg/handlers/slack/slack_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 
 	"github.com/skippbox/kubewatch/config"
+	"github.com/skippbox/kubewatch/pkg/event"
 )
 
 func TestSlackInit(t *testing.T) {
@@ -55,7 +56,7 @@ func TestSlackHandle(t *testing.T) {
 	w := watch.Event{}
 	s := &Slack{}
 
-	err := s.Handle(w)
+	err := s.Handle(event.New(w))
 
 	if err == nil {
 		t.Fatalf("Handle(): %v", err)


### PR DESCRIPTION
This PR add the watch service endpoint to watch loop, so `kubewatch` client can now catch service created event.

This PR leads to large code base refactoring:

 - `kubewatch` client now spawn two (or more if needed) goroutine to watch `Event` and `Service` endpoint.
 - A new `Event` type was added to `kubewatch`, which abstract each events type from k8s api server