### PR TITLE
Updating dependency to fix build errors

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -56,7 +56,8 @@
 		},
 		{
 			"ImportPath": "github.com/ghodss/yaml",
-			"Rev": "aa0c862057666179de291b67d9f093d12b5a8473"
+			"Comment": "v1.0.0",
+			"Rev": "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
 		},
 		{
 			"ImportPath": "github.com/go-openapi/jsonpointer",

--- a/vendor/github.com/ghodss/yaml/README.md
+++ b/vendor/github.com/ghodss/yaml/README.md
@@ -4,17 +4,17 @@
 
 ## Introduction
 
-A wrapper around [candiedyaml](https://github.com/cloudfoundry-incubator/candiedyaml) designed to enable a better way of handling YAML when marshaling to and from structs.
+A wrapper around [go-yaml](https://github.com/go-yaml/yaml) designed to enable a better way of handling YAML when marshaling to and from structs.
 
-In short, this library first converts YAML to JSON using candiedyaml and then uses `json.Marshal` and `json.Unmarshal` to convert to or from the struct. This means that it effectively reuses the JSON struct tags as well as the custom JSON methods `MarshalJSON` and `UnmarshalJSON` unlike candiedyaml. For a detailed overview of the rationale behind this method, [see this blog post](http://ghodss.com/2014/the-right-way-to-handle-yaml-in-golang/).
+In short, this library first converts YAML to JSON using go-yaml and then uses `json.Marshal` and `json.Unmarshal` to convert to or from the struct. This means that it effectively reuses the JSON struct tags as well as the custom JSON methods `MarshalJSON` and `UnmarshalJSON` unlike go-yaml. For a detailed overview of the rationale behind this method, [see this blog post](http://ghodss.com/2014/the-right-way-to-handle-yaml-in-golang/).
 
 ## Compatibility
 
-This package uses [candiedyaml](https://github.com/cloudfoundry-incubator/candiedyaml) and therefore supports [everything candiedyaml supports](https://github.com/cloudfoundry-incubator/candiedyaml#candiedyaml).
+This package uses [go-yaml](https://github.com/go-yaml/yaml) and therefore supports [everything go-yaml supports](https://github.com/go-yaml/yaml#compatibility).
 
 ## Caveats
 
-**Caveat #1:** When using `yaml.Marshal` and `yaml.Unmarshal`, binary data should NOT be preceded with the `!!binary` YAML tag. If you do, candiedyaml will convert the binary data from base64 to native binary data, which is not compatible with JSON. You can still use binary in your YAML files though - just store them without the `!!binary` tag and decode the base64 in your code (e.g. in the custom JSON methods `MarshalJSON` and `UnmarshalJSON`). This also has the benefit that your YAML and your JSON binary data will be decoded exactly the same way. As an example:
+**Caveat #1:** When using `yaml.Marshal` and `yaml.Unmarshal`, binary data should NOT be preceded with the `!!binary` YAML tag. If you do, go-yaml will convert the binary data from base64 to native binary data, which is not compatible with JSON. You can still use binary in your YAML files though - just store them without the `!!binary` tag and decode the base64 in your code (e.g. in the custom JSON methods `MarshalJSON` and `UnmarshalJSON`). This also has the benefit that your YAML and your JSON binary data will be decoded exactly the same way. As an example:
 
 ```
 BAD:
@@ -53,8 +53,8 @@ import (
 )
 
 type Person struct {
-	Name string `json:"name"`  // Affects YAML field names too.
-	Age int `json:"age"`
+	Name string `json:"name"` // Affects YAML field names too.
+	Age  int    `json:"age"`
 }
 
 func main() {
@@ -95,6 +95,7 @@ import (
 
 	"github.com/ghodss/yaml"
 )
+
 func main() {
 	j := []byte(`{"name": "John", "age": 30}`)
 	y, err := yaml.JSONToYAML(j)

--- a/vendor/github.com/ghodss/yaml/fields.go
+++ b/vendor/github.com/ghodss/yaml/fields.go
@@ -45,7 +45,11 @@ func indirect(v reflect.Value, decodingNull bool) (json.Unmarshaler, encoding.Te
 			break
 		}
 		if v.IsNil() {
-			v.Set(reflect.New(v.Type().Elem()))
+			if v.CanSet() {
+				v.Set(reflect.New(v.Type().Elem()))
+			} else {
+				v = reflect.New(v.Type().Elem())
+			}
 		}
 		if v.Type().NumMethod() > 0 {
 			if u, ok := v.Interface().(json.Unmarshaler); ok {

--- a/vendor/github.com/ghodss/yaml/yaml.go
+++ b/vendor/github.com/ghodss/yaml/yaml.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strconv"
 
-	yaml "github.com/cloudfoundry-incubator/candiedyaml"
+	"gopkg.in/yaml.v2"
 )
 
 // Marshals the object into JSON then converts JSON to YAML and returns the


### PR DESCRIPTION
This PR is aiming to fix the build error in TravisCI. https://travis-ci.org/skippbox/kubewatch/jobs/264268646#L143

In the build `godep restore` fails as the `github.com/cloudfoundry-incubator/candiedyaml` dependency in `github.com/ghodss/yaml` has been renamed on Github.

The `github.com/ghodss/yaml` project already fixed https://github.com/ghodss/yaml/commit/b452f561ef721541543fb56c93b10b6afde66b93 it on their master, so this change only updates the dependency in Godep, and vendors the changes.